### PR TITLE
Fix dockerignore to correct image builds that were breaking

### DIFF
--- a/db/.dockerignore
+++ b/db/.dockerignore
@@ -1,5 +1,5 @@
 Dockerfile
 node_modules
 .vscode
-package-lock.json
-package.json
+# package-lock.json
+# package.json

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,4 +1,4 @@
 node_modules
 Dockerfile
-package-lock.json
-package.json
+# package-lock.json
+# package.json


### PR DESCRIPTION
We (I) was ignoring crucial files (package.json, package-lock.json) and that was breaking builds.

Closes #14 

